### PR TITLE
Add Vale to lint English documentation.

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,2 +1,32 @@
-OBC
+# General technical terms
+hardcoded
+reusability
+datasheet
+
+# Development environments and tools
+venv
+udev
+Kconfig
+
+# Software and APIs
+APIs
+Config
+
+# Hardware and embedded systems
+CPU
+CPUs
+FPGA
+FPGAs
 GPIO
+GPIOs
+OBC
+
+# Products and vendor-specific names
+PICkit
+VMware
+
+# Example names and sample applications
+Blinky
+
+# Abbreviations
+cv

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,0 +1,2 @@
+OBC
+GPIO

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,29 @@
+name: vale
+
+on:
+  pull_request:
+  push:
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Asciidoctor
+        run: sudo apt-get update && sudo apt-get install -y asciidoctor
+
+      - name: Run vale
+        uses: vale-cli/vale-action@v2
+        with:
+          version: 3.14.1
+          fail_on_error: true
+          reporter: github-pr-check
+          vale_flags: "--glob=*.adoc --minAlertLevel=error"
+          files: "en"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 # nodejs
 package-lock.json
 node_modules
+
+# vale
+/.github/styles/*
+!/.github/styles/config
+!/.github/styles/config/**

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,9 @@
+StylesPath = .github/styles
+
+MinAlertLevel = suggestion
+
+Packages = Google, AsciiDoc
+Vocab = Base
+
+[*.adoc]
+BasedOnStyles = Vale, Google, AsciiDoc

--- a/en/modules/software/pages/develop-zephyr-app/hello-world.adoc
+++ b/en/modules/software/pages/develop-zephyr-app/hello-world.adoc
@@ -31,8 +31,8 @@ target_sources(app PRIVATE src/main.c)
 
 Here, the parts that need to be modified for each application are explained.
 
- * *project*: Specify the desired project name
- * *target_sources*: Specify the source code file(s)
+ * `project`: Specify the desired project name
+ * `target_sources`: Specify the source code files
 
 === prj.conf
 
@@ -109,4 +109,4 @@ After power-cycling the SC-OBC Module A1, you should see the "Hello World" strin
 Hello World! scobc_a1 Rev 2.0.0
 ----
 
-If you want to exit the tio console, first press `Ctrl + t`, followed by `q`.
+If you want to exit the `tio` console, first press `Ctrl + t`, followed by `q`.

--- a/en/modules/software/pages/develop-zephyr-app/system-monitor.adoc
+++ b/en/modules/software/pages/develop-zephyr-app/system-monitor.adoc
@@ -27,20 +27,20 @@ The BHM allows automatic data acquisition from these sensors without requiring c
 
 === System Monitor driver
 
-Currently, the following Zephyr driver APIs are provided for controlling the FPGA's System Monitor.
+Currently, The following Zephyr driver APIs are provided for controlling the System Monitor in the FPGA.
 
 [[anchor-1]]
 .System Monitor Driver API List
 [options="header"]
 |=======================
 |Function|API|Summary|Parameters|Returns
-|FPGA Watchdog|sc_kick_wdt_timer|Toggle the FPGA Watchdog Timer||
-|SEM Controller|sc_sem_get_error_count|Get the SEM error count||Current SEM error count
-|Board Health Monitor (BHM)|sc_bhm_enable|Enable the monitoring by BHM +
+|FPGA Watchdog|`sc_kick_wdt_timer`|Toggle the FPGA Watchdog Timer||
+|SEM Controller|`sc_sem_get_error_count`|Get the SEM error count||Current SEM error count
+|Board Health Monitor (BHM)|`sc_bhm_enable`|Enable the monitoring by BHM +
 *NOTE:* Currently monitoring interval is fixed at 1 second||*0:* Success +
 *-ETIMEDOUT:* Timeout for sensor device initializing
-||sc_bhm_disable|Disable the monitoring by BHM||*0:* Success
-||sc_bhm_get_obc_temp|Get the on board temperature sensor value|*pos:* Position for sensor device +
+||`sc_bhm_disable`|Disable the monitoring by BHM||*0:* Success
+||`sc_bhm_get_obc_temp`|Get the on board temperature sensor value|*pos:* Position for sensor device +
 <Selectable parameter> +
 _SCOBC_A1_TEMP_1_ +
 _SCOBC_A1_TEMP_2_ +
@@ -49,9 +49,9 @@ _SCOBC_A1_TEMP_3_ +
 *temp:* Temperature [degree]|*0:* Success +
 *-ENODEV:* Wrong parameter +
 *-EAGAIN:* No updated sensor values
-||sc_bhm_get_xadc_temp|Get the FPGA die temperature sensor value|*temp:* Temperature [degree]|*0:* Success +
+||`sc_bhm_get_xadc_temp`|Get the FPGA die temperature sensor value|*temp:* Temperature [degree]|*0:* Success +
 *-EAGAIN:* No updated sensor values
-||sc_bhm_get_obc_cv|Get the on board Current/Voltage sensor value|*pos:* Position for sensor device +
+||`sc_bhm_get_obc_cv`|Get the on board Current/Voltage sensor value|*pos:* Position for sensor device +
 <Selectable parameter> +
 _SCOBC_A1_1V0_SHUNT_ +
 _SCOBC_A1_1V0_BUS_ +
@@ -68,7 +68,7 @@ _SCOBC_A1_3V3_IO_BUS_ +
  +
 *cv:* Current sensor value [mA] / Voltage sensor value [mV] |*0:* Success +
 *-EAGAIN:* No updated sensor values
-||sc_bhm_get_xadc_cv|Get the FPGA voltage value|*pos:* Position for sensor device +
+||`sc_bhm_get_xadc_cv`|Get the FPGA voltage value|*pos:* Position for sensor device +
 <Selectable parameter> +
 _SCOBC_A1_XADC_VCCINT_ +
 _SCOBC_A1_XADC_VCCAUX_ +
@@ -110,13 +110,13 @@ target_sources(app PRIVATE src/main.c)
 
 Here, the parts that need to be modified for each application are explained.
 
- * *project*: Specify the desired project name
- * *target_sources*: Specify the source code file(s)
+ * `project`: Specify the desired project name
+ * `target_sources`: Specify the source code files
 
 === prj.conf
 
 Additional Kconfig parameters required for running the application can be specified.
-In this sample, to display temperature data of type float using printf, it is necessary to enable `CONFIG_PICOLIBC_IO_FLOAT`.
+In this sample, to display temperature data of type float using `printf`, it is necessary to enable `CONFIG_PICOLIBC_IO_FLOAT`.
 For more information about `CONFIG_PICOLIBC_IO_FLOAT`, refer to {zephyr-kconfig-picolibc-float}[CONFIG_PICOLIBC_IO_FLOAT].
 
 [source]
@@ -289,4 +289,4 @@ On Board Temperature 1 : 28.5000 [deg]
 3V3SYS Bus voltage     : 3256 [mV]
 ----
 
-If you want to exit the tio console, first press `Ctrl + t`, followed by `q`.
+If you want to exit the `tio` console, first press `Ctrl + t`, followed by `q`.

--- a/en/modules/software/pages/devicetree.adoc
+++ b/en/modules/software/pages/devicetree.adoc
@@ -11,7 +11,7 @@ The *Device Tree* is a data structure originally developed as part of the Open F
 
 This concept was later adopted and popularized in the Linux kernel, particularly for platforms like ARM and PowerPC, to enable the kernel to support multiple hardware configurations without requiring separate builds or hardcoded board-specific initialization.
 
-A Device Tree describes the physical components of a system — such as *CPUs, memory, buses, and peripheral devices* — in a structured and hierarchical format.
+A Device Tree describes the physical components of a system, such as *CPUs, memory, buses, and peripheral devices*, in a structured and hierarchical format.
 This hardware description is typically written in a human-readable *Device Tree Source (DTS)* file, which is compiled into a binary *Device Tree Blob (DTB)* using the *Device Tree Compiler (DTC)*.
 The DTB is then passed to the Linux kernel at boot time to guide hardware initialization.
 
@@ -40,13 +40,13 @@ In Zephyr, the Device Tree is used to:
 
 * Define and configure peripherals like UART, I2C, SPI, GPIO, CAN, and more.
 * Bind drivers to hardware automatically based on compatible strings.
-* Pass hardware parameters to applications via macros generated from the DTS (e.g., base addresses, interrupts, labels).
+* Pass hardware parameters to applications via macros generated from the DTS, such as base addresses, interrupts, and labels.
 * Manage multiple board variants using overlays.
 
 == Basic Structure
 
 A Device Tree is structured like a filesystem, with nodes and properties:
-Nodes represent hardware components (e.g., `/cpu`, `/memory`, `/soc/gpio@40020000`)
+Nodes represent hardware components, such as `/cpu`, `/memory`, and `/soc/gpio@40020000`.
 
 Properties are key-value pairs describing attributes like addresses, interrupts, clocks, and more.
 

--- a/en/modules/software/pages/run-zephyr-samples/hello-world.adoc
+++ b/en/modules/software/pages/run-zephyr-samples/hello-world.adoc
@@ -34,4 +34,4 @@ west flash
 
 == Confirm
 After power-cycle the SC-OBC Module A1, you should see the Hello World string on your serial console.
-If you want to exit the tio console, first press `Ctrl + t`, followed by `q`.
+If you want to exit the `tio` console, first press `Ctrl + t`, followed by `q`.

--- a/en/modules/software/pages/setup.adoc
+++ b/en/modules/software/pages/setup.adoc
@@ -13,8 +13,8 @@ This document targets *Ubuntu 24.04 x86_64* systems.
 You can use any of the following environments.
 
 * A PC with Ubuntu installed
-* A system container (e.g., Incus)
-* A virtual machine (e.g., QEMU, VirtualBox, VMware)
+* A system container, such as Incus
+* A virtual machine, such as QEMU, VirtualBox, or VMware
 * Windows Subsystem for Linux (WSL) (see TIP)
 
 For Windows or macOS users, refer to {zephyr-getting-started}[the
@@ -131,9 +131,9 @@ Install the packages required for flashing via *OpenOCD*.
 sudo apt install libftdi1 libgpiod2 libhidapi-hidraw0 libcapstone4
 ----
 
-=== Install the tio package
+=== Install the serial console package
 
-Although there are several tools available for working with a serial console, this document uses *tio*.
+Although there are several tools available for working with a serial console, this document uses *`tio`*.
 
 [source, console]
 ----
@@ -191,8 +191,8 @@ usbipd attach --wsl --busid 9-1
 
 After attaching, the serial ports appear in WSL as `/dev/ttyUSB*`.
 
-NOTE: We have confirmed that the `west flash` command takes longer to complete on WSL compared
-to native Linux. (65 KBytes writing: WSL - about 1 minute / Native Linux – about 20 seconds)
+NOTE: We have confirmed that the `west flash` command takes longer to complete on WSL than on native Linux.
+For example, writing 65 KB takes about 1 minute on WSL and about 20 seconds on native Linux.
 
 == Check the DIP Switch status
 

--- a/en/modules/software/pages/use-zephyr-drivers/gpio.adoc
+++ b/en/modules/software/pages/use-zephyr-drivers/gpio.adoc
@@ -31,8 +31,8 @@ target_sources(app PRIVATE src/main.c)
 
 Here, the parts that need to be modified for each application are explained.
 
- * *project*: Specify the desired project name
- * *target_sources*: Specify the source code file(s)
+ * `project`: Specify the desired project name
+ * `target_sources`: Specify the source code files
 
 === prj.conf
 
@@ -119,7 +119,7 @@ The relationship between the GPIOs and the User IO pins is as follows, with `GPI
 |=======================
 
 Referring to the {github-a1-sample-dev-board-overlay}[DTS overlay file for Development Board], it can be seen that `GPIO15` of the GPIO IP core is defined with the device name `user_led_0`.
-Additionally, an `led0` is assigned using the alias, which is used by Zephyr's blinky sample. However, this alias is not mandatory.
+Additionally, an `led0` is assigned using the alias, which is used by Zephyr's Blinky sample. However, this alias is not mandatory.
 
 [source, dts]
 ----
@@ -275,4 +275,4 @@ LED state: OFF
 LED state: ON
 ----
 
-If you want to exit the tio console, first press `Ctrl + t`, followed by `q`.
+If you want to exit the `tio` console, first press `Ctrl + t`, followed by `q`.

--- a/en/modules/software/pages/use-zephyr-drivers/i2c.adoc
+++ b/en/modules/software/pages/use-zephyr-drivers/i2c.adoc
@@ -31,14 +31,14 @@ target_sources(app PRIVATE src/main.c)
 
 Here, the parts that need to be modified for each application are explained.
 
- * *project*: Specify the desired project name
- * *target_sources*: Specify the source code file(s)
+ * `project`: Specify the desired project name
+ * `target_sources`: Specify the source code files
 
 === prj.conf
 
 Additional Kconfig parameters required for running the application can be specified.
 As this example uses I2C, it is necessary to set `CONFIG_I2C=y`.
-And, to display temperature data of type float using printf, it is necessary to enable `CONFIG_PICOLIBC_IO_FLOAT`.
+And, to display temperature data of type float using `printf`, it is necessary to enable `CONFIG_PICOLIBC_IO_FLOAT`.
 For more information about `CONFIG_PICOLIBC_IO_FLOAT`, refer to {zephyr-kconfig-picolibc-float}[CONFIG_PICOLIBC_IO_FLOAT].
 
 [source]
@@ -207,4 +207,4 @@ Temperature: 31.5000 [deg]
 ----
 
 
-If you want to exit the tio console, first press `Ctrl + t`, followed by `q`.
+If you want to exit the `tio` console, first press `Ctrl + t`, followed by `q`.


### PR DESCRIPTION
This PR introduces an initial Vale configuration and GitHub Actions workflow for English AsciiDoc files under `en/`.

Vale uses the Google and AsciiDoc styles, with a base vocabulary for project-specific terms.

This is intended as an initial setup to discuss whether Vale and the selected rules are a good fit for our English documentation.