### PR TITLE
gitlint: Check capitalization after commit scopes

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -3,3 +3,6 @@ regex-style-search=true
 
 [ignore-body-lines]
 regex=^(?:(?:Signed-off|Acked|Co-Authored|Reported|Tested)-by: |\[\d+\]: https:\/\/)
+
+[title-match-regex]
+regex=^([a-z0-9][a-z0-9_-]*: )+[A-Z].*


### PR DESCRIPTION
Add a title-match-regex rule to require the commit title summary to start with a capital letter after one or more colon-separated scopes.

This allows titles such as "docs: Add ..." and "drivers: audio: Fix ...", while rejecting summaries that start with a lowercase letter.