### PR TITLE
gitlint: Allow scope-less and file-based titles

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -5,4 +5,4 @@ regex-style-search=true
 regex=^(?:(?:Signed-off|Acked|Co-Authored|Reported|Tested)-by: |\[\d+\]: https:\/\/)
 
 [title-match-regex]
-regex=^([a-z0-9][a-z0-9_-]*: )+[A-Z].*
+regex=^(([a-z0-9._-]+: )+)?[A-Z].*


### PR DESCRIPTION
Allow commit titles without scopes and titles that use file names as scopes, such as ".gitignore: Add ...".

The previous regex only accepted one or more simple lowercase scopes before the summary. This rejected existing valid titles without scopes or with file-style scope names.